### PR TITLE
add shortcuts to resize panel size

### DIFF
--- a/vimrc.local
+++ b/vimrc.local
@@ -14,6 +14,14 @@ map <Leader>x :exec getline(".")<cr>
 map <C-n> :NERDTreeToggle<CR>
 map <leader>rr :NERDTreeFind<cr>
 
+" automatically rebalance windows on vim resize
+autocmd VimResized * :wincmd =
+
+" zoom a vim pane, <C-w>= to re-balance
+nnoremap <leader>- :wincmd _<cr>:wincmd \|<cr>
+nnoremap <leader>= :wincmd =<cr>
+
+
 " remove files from crlp
 set wildignore+=*/tmp/*,*.so,*.swp,*.zip,*/bower_components/*,*/node_modules/*,*/dist/*,*/vendor/*
 


### PR DESCRIPTION
autocmd VimResized * :wincmd = 
avoid conflict between vim and tmux panels. For example, without this configuration, if I have 2 vim panels split vertically and open another tmux panel vertically, this tmux panel will be placed in the right vim panel and the right vim panel will be so thin. With this configuration, the two vim panels will be in the same size after the split.

the other two configurations permit zoom in and out to a vim panel and can be used with zoom from tmux (prefix + z)