### PR TITLE
avoid leaving tmux

### DIFF
--- a/tmux.conf
+++ b/tmux.conf
@@ -29,6 +29,12 @@ bind -n C-Right resize-pane -R 10
 bind -n C-Down resize-pane -D 5
 bind -n C-Up resize-pane -U
 
+# open a new tmux session without leaving tmux
+bind-key C-b send-keys 'tat && exit' 'C-m'
+
+# kill a session without leaving tmux
+bind-key K run-shell 'tmux switch-client -n \; kill-session -t "$(tmux display-message -p "#S")" || tmux kill-session'
+
 set -g prefix2 C-s
 
 # start window numbers at 1 to match keyboard order with tmux window order
@@ -45,8 +51,6 @@ set -g status-fg '#aaaaaa'
 # increase scrollback lines
 set -g history-limit 10000
 
-# prefix -> back-one-character
-bind-key C-b send-prefix
 # prefix-2 -> forward-incremental-history-search
 bind-key C-s send-prefix -2
 

--- a/zshrc
+++ b/zshrc
@@ -39,6 +39,16 @@ _load_settings() {
 }
 _load_settings "$HOME/.zsh/configs"
 
+_not_inside_tmux() { [[ -z "$TMUX" ]] }
+
+ensure_tmux_is_running() {
+  if _not_inside_tmux; then
+    tat
+  fi
+}
+
+ensure_tmux_is_running
+
 # Local config
 [[ -f ~/.zshrc.local ]] && source ~/.zshrc.local
 


### PR DESCRIPTION
With this PR it will be possible to:
- open a new session without leaving tmux: navigate to a new folder, press `prefix C-b`  and a new session will be opened.
- kill a session without leaving tmux: navigate to the session you want to kill and press `prefix K`.
- besides that, the configuration in zshrc opens a new tmux session everytime a new terminal is opened (you will always be in a tmux session).