### PR TITLE
add vi like commands

### DIFF
--- a/tmux.conf
+++ b/tmux.conf
@@ -3,6 +3,9 @@ set -g default-terminal 'screen-256color'
 
 # act like vim
 setw -g mode-keys vi
+bind-key -T copy-mode-vi 'v' send -X begin-selection
+bind-key -T copy-mode-vi 'y' send -X copy-selection-and-cancel
+
 bind -n C-h run "(tmux display-message -p '#{pane_title}' | grep -iq vim && tmux send-keys C-h) || tmux select-pane -L"
 bind -n C-j run "(tmux display-message -p '#{pane_title}' | grep -iq vim && tmux send-keys C-j) || tmux select-pane -D"
 bind -n C-k run "(tmux display-message -p '#{pane_title}' | grep -iq vim && tmux send-keys C-k) || tmux select-pane -U"


### PR DESCRIPTION
this modification permits using of `v` (instead of space) and `y`(instead of enter) to select a text in tmux (after pressing <Prefix-[>)