### PR TITLE
Add ultisnips and remove InsertTabWrapper

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@
 - install https://github.com/sindresorhus/pure
 if in macOS, install
 - https://robots.thoughtbot.com/tmux-copy-paste-on-os-x-a-better-future
+- install vim-pathogen, ultisnips + vim-snippets
+
 thoughtbot dotfiles
 ===================
 

--- a/UltiSnips/ruby.snippets
+++ b/UltiSnips/ruby.snippets
@@ -1,0 +1,3 @@
+snippet pry
+require 'pry'; binding.pry
+endsnippet

--- a/vimrc
+++ b/vimrc
@@ -86,21 +86,6 @@ set colorcolumn=+1
 set number
 set numberwidth=5
 
-" Tab completion
-" will insert tab at beginning of line,
-" will use completion if not at beginning
-set wildmode=list:longest,list:full
-function! InsertTabWrapper()
-  let col = col('.') - 1
-  if !col || getline('.')[col - 1] !~ '\k'
-    return "\<tab>"
-  else
-    return "\<c-p>"
-  endif
-endfunction
-inoremap <Tab> <c-r>=InsertTabWrapper()<cr>
-inoremap <S-Tab> <c-n>
-
 " Switch between the last two files
 nnoremap <leader><leader> <c-^>
 

--- a/vimrc.local
+++ b/vimrc.local
@@ -89,3 +89,10 @@ endif
 
 " reduce default opdate time from 4s to 250ms (update signs in gitgutter, for example)
 set updatetime=250
+
+" install pathogen
+execute pathogen#infect()
+syntax on
+filetype plugin indent on
+
+let g:UltiSnipsSnippetsDir = '~/dotfiles/UltiSnips'


### PR DESCRIPTION
I removed InsertTabWrapper because it was conflicting with UltiSnips shortcuts. I know that I can change the shortcuts but tab seems to be a good choice for this. 

Moreover, I can use <C-p> as auto-completion. It is much slower than InsertTabWrapper but I will try to use it.  