### PR TITLE
remove whitespaces on save

### DIFF
--- a/vimrc.local
+++ b/vimrc.local
@@ -107,3 +107,17 @@ let g:tslime_always_current_window = 1
 vmap <C-c><C-c> <Plug>SendSelectionToTmux
 nmap <C-c><C-c> <Plug>NormalModeSendToTmux
 nmap <C-c>r <Plug>SetTmuxVars
+
+function! <SID>StripTrailingWhitespaces()
+  " Preparation: save last search, and cursor position.
+  let _s=@/
+  let l = line(".")
+  let c = col(".")
+  " Do the business:
+  %s/\s\+$//e
+  " Clean up: restore previous search history, and cursor position
+  let @/=_s
+  call cursor(l, c)
+endfunction
+
+autocmd BufWritePre *.rb,*.js :call <SID>StripTrailingWhitespaces()


### PR DESCRIPTION
In this PR it was added a command to remove whitespaces at the end of a line on save.

source: http://vimcasts.org/episodes/tidying-whitespace/