### PR TITLE
Change <leader><leader> shortcut and remove camelCaseMotion shortcuts

### DIFF
--- a/vimrc
+++ b/vimrc
@@ -86,9 +86,6 @@ set colorcolumn=+1
 set number
 set numberwidth=5
 
-" Switch between the last two files
-nnoremap <leader><leader> <c-^>
-
 " Get off my lawn
 nnoremap <Left> :echoe "Use h"<CR>
 nnoremap <Right> :echoe "Use l"<CR>

--- a/vimrc.local
+++ b/vimrc.local
@@ -125,21 +125,4 @@ autocmd BufWritePre *.rb,*.js :call <SID>StripTrailingWhitespaces()
 " change from test to production code and vice-versa using projectionist
 nnoremap <leader><leader> :A<CR>
 
-" using CamelCaseMotion plugin - cannot use default behavior cause <Leader>w is already mapped to write the buffer in
-" file system
-map <silent> w <Plug>CamelCaseMotion_w
-map <silent> b <Plug>CamelCaseMotion_b
-map <silent> e <Plug>CamelCaseMotion_e
-map <silent> ge <Plug>CamelCaseMotion_ge
-sunmap w
-sunmap b
-sunmap e
-sunmap ge
-omap <silent> iw <Plug>CamelCaseMotion_iw
-xmap <silent> iw <Plug>CamelCaseMotion_iw
-omap <silent> ib <Plug>CamelCaseMotion_ib
-xmap <silent> ib <Plug>CamelCaseMotion_ib
-omap <silent> ie <Plug>CamelCaseMotion_ie
-xmap <silent> ie <Plug>CamelCaseMotion_ie
-imap <silent> <S-Left> <C-o><Plug>CamelCaseMotion_b
-imap <silent> <S-Right> <C-o><Plug>CamelCaseMotion_w
+nnoremap src :source $MYVIMRC<cr>

--- a/vimrc.local
+++ b/vimrc.local
@@ -123,7 +123,23 @@ endfunction
 autocmd BufWritePre *.rb,*.js :call <SID>StripTrailingWhitespaces()
 
 " change from test to production code and vice-versa using projectionist
-nnoremap <C-a> :A<CR>
+nnoremap <leader><leader> :A<CR>
 
-" using CamelCaseMotion plugin
-call camelcasemotion#CreateMotionMappings('<leader>')
+" using CamelCaseMotion plugin - cannot use default behavior cause <Leader>w is already mapped to write the buffer in
+" file system
+map <silent> w <Plug>CamelCaseMotion_w
+map <silent> b <Plug>CamelCaseMotion_b
+map <silent> e <Plug>CamelCaseMotion_e
+map <silent> ge <Plug>CamelCaseMotion_ge
+sunmap w
+sunmap b
+sunmap e
+sunmap ge
+omap <silent> iw <Plug>CamelCaseMotion_iw
+xmap <silent> iw <Plug>CamelCaseMotion_iw
+omap <silent> ib <Plug>CamelCaseMotion_ib
+xmap <silent> ib <Plug>CamelCaseMotion_ib
+omap <silent> ie <Plug>CamelCaseMotion_ie
+xmap <silent> ie <Plug>CamelCaseMotion_ie
+imap <silent> <S-Left> <C-o><Plug>CamelCaseMotion_b
+imap <silent> <S-Right> <C-o><Plug>CamelCaseMotion_w


### PR DESCRIPTION
- <C-a> shortcut were conflicting with the shortcut that increases a number by 1 (useful when creating variables with names at the end). So, I decided to use <leader><leader> as shortcut to alternate between source and spec (most useful than the last file)
- besides that, I realize that camelCaseMotion shortcut <leader>w was conflicting with one of the shortcuts I use the most to write a buffer. I need to think more about it. Remapping `w`, `b` and `e` is not an option cause it causes some trouble. For example, it is very common to select an entire variable like `foo_bar` instead of only `foo`

