### PR TITLE
Add ruby block text object

### DIFF
--- a/vimrc.bundles
+++ b/vimrc.bundles
@@ -71,6 +71,8 @@ Plug 'bkad/CamelCaseMotion'
 Plug 'sjl/gundo.vim'
 Plug 'dustinfarris/vim-htmlbars-inline-syntax'
 Plug 'tpope/vim-abolish'
+Plug 'kana/vim-textobj-user' | Plug 'kana/vim-textobj-line'
+Plug 'nelstrom/vim-textobj-rubyblock'
 
 if filereadable(expand("~/.vimrc.bundles.local"))
   source ~/.vimrc.bundles.local


### PR DESCRIPTION
Now, it is possible to select a ruby block with `r` (stands for Ruby block) motion. For example, `var` expands for a whole Ruby block. Repeating `ar` will expand one more level and `ir` should shrink one level (it does not work)