### PR TITLE
add *snippets* to gitignore

### DIFF
--- a/gitignore
+++ b/gitignore
@@ -12,3 +12,4 @@ tmp/**/*
 !tmp/cache/.keep
 *.pyc
 .projections.json
+*snippets*


### PR DESCRIPTION
Permite criar arquivos como `snippets`, snippets.rb`, etc sem ser trackeado pelo git.