### PR TITLE
Use ctrlp as second option, change easymotion prefix, add ale supressing warning variable

### DIFF
--- a/vimrc.local
+++ b/vimrc.local
@@ -136,3 +136,11 @@ autocmd BufReadPost fugitive://* set bufhidden=delete
 autocmd BufRead,BufNewFile *.js HighlightInlineHbs
 
 set nofoldenable
+
+nnoremap <leader>f :Files<cr>
+nnoremap <leader>F :FF<cr>
+
+"Use MRU as default in CtrlP
+let g:ctrlp_map='<c-p>'
+let g:ctrlp_cmd='CtrlPMRU'
+let g:ctrlp_mruf_relative = 1 " search only in project - without it, it will search from $HOME =(

--- a/vimrc.local
+++ b/vimrc.local
@@ -144,3 +144,7 @@ nnoremap <leader>F :FF<cr>
 let g:ctrlp_map='<c-p>'
 let g:ctrlp_cmd='CtrlPMRU'
 let g:ctrlp_mruf_relative = 1 " search only in project - without it, it will search from $HOME =(
+
+map ff <Plug>(easymotion-prefix)
+
+let g:ale_emit_conflict_warnings = 0


### PR DESCRIPTION
the `g:ale_emit_conflict_warnings` was necessary because I tried to install a plugin to run eslint without success. For a reason I cannot discovery yet, the plugin was not desinstalled even after removing its directory and after running `:PlugUpdate`