### PR TITLE
Add log to tmux window

### DIFF
--- a/tmux.conf
+++ b/tmux.conf
@@ -67,6 +67,9 @@ bind-key C-j choose-tree
 set -g window-active-style 'bg=colour232'
 set -g window-style 'bg=colour234'
 
+# Use Prefix-P to log a panel in ~/tmuxlog.txt
+bind P pipe-pane -o "cat >>~/#W.log" \; display "Toggled logging to ~/#W.log.txt"
+
 set -g @plugin 'tmux-plugins/tpm'
 set -g @plugin 'tmux-plugins/tmux-sensible'
 set -g @plugin 'tmux-plugins/tmux-resurrect'


### PR DESCRIPTION
Use Prefix-P to log the current pane. The log archive will be placed in home directory with the name of the tmux window